### PR TITLE
Fix: garbage data in tile memory with 8x8 sprites

### DIFF
--- a/common/src/OAMManager.c
+++ b/common/src/OAMManager.c
@@ -1,5 +1,6 @@
 #include "OAMManager.h"
 #include "BankManager.h"
+#include <gb/hardware.h>
 
 UINT8 last_sprite_loaded = 0;
 UINT8 sprites_pal[256];
@@ -7,7 +8,7 @@ UINT8 sprites_pal[256];
 UINT8 LoadSprite(struct TilesInfoInternal* data) {
 	UINT8 i;
 	UINT8* sprites_pal_ptr = &sprites_pal[last_sprite_loaded];
-	UINT8 frame_size = data->width >> 3;
+	UINT8 frame_size = data->width >> ((LCDC_REG & 0x4) ? 3 : 4);
 	UINT8 n_tiles = data->num_frames << frame_size;
 	UINT8* palette_idx = data->color_data;
 


### PR DESCRIPTION
I'm working on a game that uses only 8x8 sprites and noticed that there was garbage data in the tile memory. This change intends to fix it. Comments welcome!

Before:
<img width="642" alt="Screenshot 2020-06-06 at 21 00 33" src="https://user-images.githubusercontent.com/2312529/83951555-df87a600-a83a-11ea-897f-0661fe6b8f70.png">

After:
<img width="642" alt="Screenshot 2020-06-06 at 21 01 55" src="https://user-images.githubusercontent.com/2312529/83951565-f3330c80-a83a-11ea-9fe6-fa0a40d880a7.png">
