### PR TITLE
Linux build improvements

### DIFF
--- a/common/src/MakefileCommon
+++ b/common/src/MakefileCommon
@@ -79,7 +79,7 @@ PNGS        = $(foreach dir,../res,$(notdir $(wildcard $(dir)/*.png)))
 MUSICS      = $(foreach dir,../res/music,$(notdir $(wildcard $(dir)/*.mod)))
 OBJS = $(GBMS:%.gbm=$(OBJDIR_RES)/%.gbm.o) $(GBRS:%.gbr=$(OBJDIR_RES)/%.gbr.o) $(PNGS:%.png=$(OBJDIR_RES)/%.png.o) $(MUSICS:%.mod=$(OBJDIR_RES)/%.mod.o) $(ASMS:%.s=$(OBJDIR)/%.o) $(CLASSES:%.c=$(OBJDIR)/%.o)
 OBJS_ZGB = $(ASMS_ZGB:%.s=$(OBJDIR_ZGB)/%.o) $(CLASSES_ZGB:%.c=$(OBJDIR_ZGB)/%.o)
-OBJS_ZGB_LIB = $(ASMS_ZGB:%.s=\n%.o) $(CLASSES_ZGB:%.c=\n%.o)
+OBJS_ZGB_LIB = $(ASMS_ZGB:%.s=%.o) $(CLASSES_ZGB:%.c=%.o)
 
 #prevent gbr2c and gbm2c intermediate files from being deleted
 .SECONDARY: $(GBMS:%.gbm=$(OBJDIR_RES_SRC)/%.gbm.c) $(GBRS:%.gbr=$(OBJDIR_RES_SRC)/%.gbr.c) $(PNGS:%.png=$(OBJDIR_RES_SRC)/%.png.c)
@@ -156,7 +156,12 @@ $(OBJDIR)/zgb/%.o: $(ZGB_PATH_UNIX)/src/%.c
 $(OBJDIR_ZGB)/zgb.lib: $(OBJDIR_ZGB) $(OBJS_ZGB)
 	@echo creating zgb.lib
 	@rm -f $(OBJDIR_ZGB)/zgb.lib
+ifeq ($(OS),Windows_NT)
 	@echo -e "$(OBJS_ZGB_LIB)" >> $(OBJDIR_ZGB)/zgb.lib
+else
+	@echo "$(OBJS_ZGB_LIB)" >> $(OBJDIR_ZGB)/zgb.lib
+endif
+	@sed -i -e 's/ /\n/g' $(OBJDIR_ZGB)/zgb.lib
 
 #Project files------------------------------------
 $(OBJDIR)/%.o: %.s

--- a/common/src/MakefileCommon
+++ b/common/src/MakefileCommon
@@ -1,5 +1,20 @@
 ZGB_PATH_UNIX := $(subst ',,$(subst \,/,'$(ZGB_PATH)'))
-GBDK_HOME := $(ZGB_PATH_UNIX)/../env/gbdk
+
+# default to no extension for all OSes
+EXEEXTENSION =
+
+# Only set GBDK_HOME if not already set
+# This allows override with local version
+ifeq ($(GBDK_HOME),)
+	GBDK_HOME := $(ZGB_PATH_UNIX)/../env/gbdk
+	# If GBDK_HOME is not defined and the OS is not Windows
+	# then the ENV binaries will get used, which mean they
+	# need a .exe extension to work with WINE on Linux/etc.
+	ifneq ($(OS),Windows_NT)
+		EXEEXTENSION=.exe
+	endif
+endif
+
 PATH := $(ZGB_PATH_UNIX)/../env/make-3.81-bin/bin;$(ZGB_PATH_UNIX)/../env/gbdk/bin;$(ZGB_PATH_UNIX)/../env/msys/bin;$(PATH)
 
 #--- Default build will be release. Can be overiden passing BUILD_TYPE = debug as a parameter
@@ -11,18 +26,18 @@ OBJDIR_RES = ../$(BUILD_TYPE)/res
 OBJDIR_ZGB = ../$(BUILD_TYPE)/zgb
 BINDIR = ../bin
 
-SDCC = sdcc
-SDASGB = sdasgb
-SDLDGB = sdldgb
-MAKEBIN = makebin
-IHXCHECK = ihxcheck
+SDCC = $(GBDK_HOME)/bin/sdcc$(EXEEXTENSION)
+SDASGB = $(GBDK_HOME)/bin/sdasgb$(EXEEXTENSION)
+SDLDGB = $(GBDK_HOME)/bin/sdldgb$(EXEEXTENSION)
+MAKEBIN = $(GBDK_HOME)/bin/makebin$(EXEEXTENSION)
+IHXCHECK = $(GBDK_HOME)/bin/ihxcheck$(EXEEXTENSION)
 
-GBR2C = $(ZGB_PATH_UNIX)/../tools/gbr2c/gbr2c
-GBM2C = $(ZGB_PATH_UNIX)/../tools/gbm2c/gbm2c
-PNGB = $(ZGB_PATH_UNIX)/../env/pngb
-MOD2GBT = $(ZGB_PATH_UNIX)/../env/mod2gbt
-BGB = $(ZGB_PATH_UNIX)/../env/bgb/bgb
-ROMVIEW = $(ZGB_PATH_UNIX)/../env/romview/romview.exe
+GBR2C = $(ZGB_PATH_UNIX)/../tools/gbr2c/gbr2c$(EXEEXTENSION)
+GBM2C = $(ZGB_PATH_UNIX)/../tools/gbm2c/gbm2c$(EXEEXTENSION)
+PNGB = $(ZGB_PATH_UNIX)/../env/pngb$(EXEEXTENSION)
+MOD2GBT = $(ZGB_PATH_UNIX)/../env/mod2gbt$(EXEEXTENSION)
+BGB = $(ZGB_PATH_UNIX)/../env/bgb/bgb$(EXEEXTENSION)
+ROMVIEW = $(ZGB_PATH_UNIX)/../env/romview/romview$(EXEEXTENSION)
 
 CFLAGS = -mgbz80 --no-std-crt0 --fsigned-char --use-stdout -Dnonbanked= -I$(GBDK_HOME)/include -I$(GBDK_HOME)/include/asm $(BUILD_DEFS) -I../include -I$(ZGB_PATH_UNIX)/include
 CFLAGS += -DFILE_NAME=$(basename $(<F))


### PR DESCRIPTION
A couple changes for MakefileCommon to work better by default on Linux (it doesn't "out of the box" right now). No worries if you don't want to merge them.  :)

These * have not * been tested on Windows yet since my Win VM needs a little work at the moment, so testing them would be a good idea.

- Only set GBDK_HOME if not already set, allows for local override if present. 
- If GBDK_HOME is not set, and the OS is not windows, then ENV binaries are being used and a .exe extension is required for WINE. It seems an explicit path is also required by WINE, so this adds that since it is known.

- Fix zgb.lib creation for Linux. The current method was producing a line at the start of it with `-e \n` which resulted in the following error:
  `?ASlink-Warning-Cannot open library module ../Release/zgb/-e .rel`
  If the -e was removed it still errored with 
  `?ASlink-Warning-Cannot open library module ../Release/zgb/ .rel`


