### PR TITLE
Add some global variable intializations

### DIFF
--- a/common/src/Scroll.c
+++ b/common/src/Scroll.c
@@ -24,8 +24,8 @@ UINT8 GetTileReplacement(UINT8* tile_ptr, UINT8* tile);
 
 unsigned char* scroll_map = 0;
 unsigned char* scroll_cmap = 0;
-INT16 scroll_x;
-INT16 scroll_y;
+INT16 scroll_x = 0;
+INT16 scroll_y = 0;
 UINT16 scroll_w;
 UINT16 scroll_h;
 UINT16 scroll_tiles_w;

--- a/common/src/SpriteManager.c
+++ b/common/src/SpriteManager.c
@@ -130,8 +130,8 @@ __endasm;
 extern UINT8* oam;
 extern UINT8* oam0;
 extern UINT8* oam1;
-UINT8 THIS_IDX;
-struct Sprite* THIS;
+UINT8 THIS_IDX = 0;
+struct Sprite* THIS = 0;
 void SpriteManagerUpdate() {
 	SPRITEMANAGER_ITERATE(THIS_IDX, THIS) {
 		if(!THIS->marked_for_removal) {

--- a/common/src/main.c
+++ b/common/src/main.c
@@ -33,8 +33,8 @@ void PlayMusic(const unsigned char* music[], unsigned char bank, unsigned char l
 	}
 }
 
-UINT8 vbl_count;
-INT16 old_scroll_x, old_scroll_y;
+UINT8 vbl_count = 0;
+INT16 old_scroll_x = 0, old_scroll_y = 0;
 UINT8 music_mute_frames = 0;
 void vbl_update() {
 	vbl_count ++;
@@ -91,6 +91,7 @@ void main() {
 #ifdef CGB
 	cpu_fast();
 #endif
+	gbt_stop();
 
 	PUSH_BANK(1);
 	InitStates();


### PR DESCRIPTION
Initialize a couple variables and states that were triggering non-initialized RAM access exceptions in emulators.