### PR TITLE
Var initis for sprite_manager_updateables[]

### DIFF
--- a/common/include/SpriteManager.h
+++ b/common/include/SpriteManager.h
@@ -19,6 +19,7 @@ extern UINT8 sprite_manager_updatables[];
 extern UINT8 THIS_IDX;
 extern struct Sprite* THIS;
 
+void SpriteManagerInit();
 void SpriteManagerReset();
 
 void SpriteManagerLoad(UINT8 sprite_type);

--- a/common/src/Scroll.c
+++ b/common/src/Scroll.c
@@ -24,8 +24,8 @@ UINT8 GetTileReplacement(UINT8* tile_ptr, UINT8* tile);
 
 unsigned char* scroll_map = 0;
 unsigned char* scroll_cmap = 0;
-INT16 scroll_x;
-INT16 scroll_y;
+INT16 scroll_x = 0;
+INT16 scroll_y = 0;
 UINT16 scroll_w;
 UINT16 scroll_h;
 UINT16 scroll_tiles_w;

--- a/common/src/SpriteManager.c
+++ b/common/src/SpriteManager.c
@@ -130,8 +130,8 @@ __endasm;
 extern UINT8* oam;
 extern UINT8* oam0;
 extern UINT8* oam1;
-UINT8 THIS_IDX;
-struct Sprite* THIS;
+UINT8 THIS_IDX = 0;
+struct Sprite* THIS = 0;
 void SpriteManagerUpdate() {
 	SPRITEMANAGER_ITERATE(THIS_IDX, THIS) {
 		if(!THIS->marked_for_removal) {

--- a/common/src/SpriteManager.c
+++ b/common/src/SpriteManager.c
@@ -15,6 +15,15 @@ DECLARE_VECTOR(sprite_manager_updatables, N_SPRITE_MANAGER_SPRITES);
 
 UINT8 sprite_manager_removal_check;
 
+void SpriteManagerInit() {
+	UINT8 i;
+
+	// Zero out array since compiler doesn't do it for N with [N] = {0};
+	for(i = 0u; i != N_SPRITE_MANAGER_SPRITES; ++ i) {
+		sprite_manager_updatables[i] = 0;
+	}
+}
+
 void SpriteManagerReset() {
 	UINT8 i;
 

--- a/common/src/main.c
+++ b/common/src/main.c
@@ -33,8 +33,8 @@ void PlayMusic(const unsigned char* music[], unsigned char bank, unsigned char l
 	}
 }
 
-UINT8 vbl_count;
-INT16 old_scroll_x, old_scroll_y;
+UINT8 vbl_count = 0;
+INT16 old_scroll_x = 0, old_scroll_y = 0;
 UINT8 music_mute_frames = 0;
 void vbl_update() {
 	vbl_count ++;
@@ -91,6 +91,7 @@ void main() {
 #ifdef CGB
 	cpu_fast();
 #endif
+	gbt_stop();
 
 	PUSH_BANK(1);
 	InitStates();

--- a/common/src/main.c
+++ b/common/src/main.c
@@ -92,6 +92,7 @@ void main() {
 	cpu_fast();
 #endif
 	gbt_stop();
+  SpriteManagerInit();
 
 	PUSH_BANK(1);
 	InitStates();


### PR DESCRIPTION
I split this one out from the others since it isn't clear whether it's the approach you would take.

It's branched from the other PR so it has those changes rolled in, my bad. I could re-PR it on a clean branch if needed.

Initialize sprite_manager_updatables[] to zero to fix non-initialized RAM exeption.

If I remember correctly, currently SDCC will only initialize the first element of an array that is initialized with `SomeArray[N] = {0};` instead of all elements. So this just adds an init function.