### PR TITLE
Avoid error in install.bat

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -1,1 +1,1 @@
-setx ZGB_PATH %cd%\common
+setx ZGB_PATH "%cd%\common"


### PR DESCRIPTION
In W10 I am getting this error when executing the install.bat. This is solved putting the path inside double quotes.
The error is:
ERROR: Invalid syntax. Default option is not allowed more than "2" time(s).