### PR TITLE
Fix SGB Borders not working on PAL SNES / SGB

### DIFF
--- a/common/src/main.c
+++ b/common/src/main.c
@@ -97,6 +97,10 @@ __endasm;
 extern UINT8 last_bg_pal_loaded;
 UINT16 default_palette[] = {RGB(31, 31, 31), RGB(20, 20, 20), RGB(10, 10, 10), RGB(0, 0, 0)};
 void main() {
+	// this delay is required for PAL SNES SGB border commands to work
+	for (UINT8 i = 4; i != 0; i--) {
+		wait_vbl_done();
+	}
 #ifdef CGB
 	UINT8 i;
 	cpu_fast();


### PR DESCRIPTION
fixes #45 by always adding a delay of 4 frames at the beginning of main. It seems to be enough to make loading of SGB Borders work on my PAL SNES / SGB. Adding the delay later on makes it still fail. I did not really check why. I also doubt this would really interfere with NTSC systems as there the problem did not exist and a delay of 4 frames for every game just at startup is not much. The only thing i don't know is if wait_vbl_done being called there could have some impact with other code of your engine